### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
           account_key: ${{ secrets.GCLOUD_KEY }}
       - name: Publish to Registry
         id: docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: gcr.io/${{ secrets.GCLOUD_PROJECT_ID }}/app1
           username: ${{ steps.gcloud.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore